### PR TITLE
use local var instead of global

### DIFF
--- a/kong-oidc-1.1.0-1.rockspec
+++ b/kong-oidc-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "kong-oidc"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/jerfer/kong-oidc",
+    url = "git://github.com/egyel/kong-oidc",
     tag = "master",
     dir = "kong-oidc"
 }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -81,7 +81,7 @@ end
 
 function M.injectAccessToken(accessToken, headerName, bearerToken)
   ngx.log(ngx.DEBUG, "Injecting " .. headerName)
-  token = accessToken
+  local token = accessToken
   if (bearerToken) then
     token = formatAsBearerToken(token)
   end


### PR DESCRIPTION
With the latest Kong 1.4.0, Lua through a warning to use local variable instead of global one. This fixed the issue.
The source.url should be changed back to Revomatico!