### PR TITLE
Bearer JWT verify, auth/acl chaining, group/credential handling fixes

### DIFF
--- a/.env
+++ b/.env
@@ -2,9 +2,9 @@ BUILD_IMG_NAME=nokia/kong-oidc
 INTEGRATION_PATH=test/docker/integration
 UNIT_PATH=test/docker/unit
 
-KONG_BASE_TAG=:1.0-centos
+KONG_BASE_TAG=:2.2.1-centos
 KONG_TAG=
-KONG_DB_TAG=:10.1
+KONG_DB_TAG=:12
 KONG_DB_PORT=5432
 KONG_DB_USER=kong
 KONG_DB_PW=kong

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If you're using `luarocks` execute the following:
 | `config.disable_id_token_header`            | no                                         | false    | Disable passing the ID Token to the upstream server                                                                                                                                     |
 | `config.disable_access_token_header`        | no                                         | false    | Disable passing the Access Token to the upstream server                                                                                                                                 |
 | `config.groups_claim`                       | groups                                     | false    | Name of the claim in the token to get groups from                                                                                                                                       |
+| `config.skip_already_auth_requests`         | no                                         | false    | Ignore requests where credentials have already been set by a higher priority plugin such as basic-auth                                                                                  |
 
 ### Enabling kong-oidc
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ If you're using `luarocks` execute the following:
 | `config.disable_access_token_header`        | no                                         | false    | Disable passing the Access Token to the upstream server                                                                                                                                 |
 | `config.groups_claim`                       | groups                                     | false    | Name of the claim in the token to get groups from                                                                                                                                       |
 | `config.skip_already_auth_requests`         | no                                         | false    | Ignore requests where credentials have already been set by a higher priority plugin such as basic-auth                                                                                  |
+| `config.bearer_jwt_auth_enable`             | no                                         | false    | Authenticate based on JWT (ID) token provided in Authorization (Bearer) header. Checks iss, sub, aud, exp, iat (as in ID token). `config.discovery` must be defined to discover JWKS    |
+| `config.bearer_jwt_auth_allowed_auds`       |                                            | false    | List of JWT token `aud` values allowed when validating JWT token in Authorization header. If not provided, uses value from `config.client_id`                                           |
+| `config.bearer_jwt_auth_signing_algs`       | [ 'RS256' ]                                | false    | List of allowed signing algorithms for Authorization header JWT token validation. Must match to OIDC provider and `resty-openidc` supported algorithms                                  |
 
 ### Enabling kong-oidc
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ ngx.ctx.authenticated_credential = {
 }
 ```
 
+For successfully authenticated request, possible (anonymous) consumer identity set by higher priority plugin is cleared as part of setting the credentials.
+
 The plugin will try to retrieve the user's groups from a field in the token (default `groups`) and set `kong.ctx.shared.authenticated_groups` so that Kong authorization plugins can make decisions based on the user's group membership.
 
 ## Dependencies
@@ -153,6 +155,8 @@ Server: kong/0.11.0
 ```
 
 ### Upstream API request
+
+For successfully authenticated request, the plugin will set upstream header `X-Credential-Identifier` to contain `sub` claim from user info, ID token or introspection result. Header `X-Anonymous-Consumer` is cleared.
 
 The plugin adds a additional `X-Userinfo`, `X-Access-Token` and `X-Id-Token` headers to the upstream request, which can be consumer by upstream server. All of them are base64 encoded:
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ If you're using `luarocks` execute the following:
 | `config.bearer_jwt_auth_enable`             | no                                         | false    | Authenticate based on JWT (ID) token provided in Authorization (Bearer) header. Checks iss, sub, aud, exp, iat (as in ID token). `config.discovery` must be defined to discover JWKS    |
 | `config.bearer_jwt_auth_allowed_auds`       |                                            | false    | List of JWT token `aud` values allowed when validating JWT token in Authorization header. If not provided, uses value from `config.client_id`                                           |
 | `config.bearer_jwt_auth_signing_algs`       | [ 'RS256' ]                                | false    | List of allowed signing algorithms for Authorization header JWT token validation. Must match to OIDC provider and `resty-openidc` supported algorithms                                  |
+| `config.header_names`                       |                                            | false    | List of custom upstream HTTP headers to be added based on claims. Must have same number of elements as `config.header_claims`. Example: `[ 'x-oidc-email', 'x-oidc-email-verified' ]`   |
+| `config.header_claims`                      |                                            | false    | List of claims to be used as source for custom upstream headers. Claims are sourced from Userinfo, ID Token, Bearer JWT, Introspection, depending on auth method.  Use only claims containing simple string values. Example: `[ 'email', 'email_verified'` |
 
 ### Enabling kong-oidc
 

--- a/kong-oidc-1.2.1-1.rockspec
+++ b/kong-oidc-1.2.1-1.rockspec
@@ -22,7 +22,7 @@ description = {
     license = "Apache 2.0"
 }
 dependencies = {
-    "lua-resty-openidc ~> 1.7.2-1"
+    "lua-resty-openidc ~> 1.7.4-1"
 }
 build = {
     type = "builtin",

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -41,7 +41,9 @@ function handle(oidcConfig)
     if response then
       utils.setCredentials(response)
       utils.injectGroups(response, oidcConfig.groups_claim)
-      utils.injectUser(response, oidcConfig.userinfo_header_name)
+      if not oidcConfig.disable_userinfo_header then
+        utils.injectUser(response, oidcConfig.userinfo_header_name)
+      end
       return
     end
   end
@@ -51,7 +53,9 @@ function handle(oidcConfig)
     if response then
       utils.setCredentials(response)
       utils.injectGroups(response, oidcConfig.groups_claim)
-      utils.injectUser(response, oidcConfig.userinfo_header_name)
+      if not oidcConfig.disable_userinfo_header then
+        utils.injectUser(response, oidcConfig.userinfo_header_name)
+      end
     end
   end
 

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -15,6 +15,14 @@ function OidcHandler:access(config)
   OidcHandler.super.access(self)
   local oidcConfig = utils.get_options(config, ngx)
 
+  -- partial support for plugin chaining: allow skipping requests, where higher priority
+  -- plugin has already set the credentials. The 'config.anomyous' approach to define
+  -- "and/or" relationship between auth plugins is not utilized
+  if oidcConfig.skip_already_auth_requests and kong.client.get_credential() then
+    ngx.log(ngx.DEBUG, "OidcHandler ignoring already auth request: " .. ngx.var.request_uri)
+    return
+  end
+
   if filter.shouldProcessRequest(oidcConfig) then
     session.configure(config)
     handle(oidcConfig)

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -41,6 +41,7 @@ function handle(oidcConfig)
     if response then
       utils.setCredentials(response)
       utils.injectGroups(response, oidcConfig.groups_claim)
+      utils.injectHeaders(oidcConfig.header_names, oidcConfig.header_claims, { response })
       if not oidcConfig.disable_userinfo_header then
         utils.injectUser(response, oidcConfig.userinfo_header_name)
       end
@@ -53,6 +54,7 @@ function handle(oidcConfig)
     if response then
       utils.setCredentials(response)
       utils.injectGroups(response, oidcConfig.groups_claim)
+      utils.injectHeaders(oidcConfig.header_names, oidcConfig.header_claims, { response })
       if not oidcConfig.disable_userinfo_header then
         utils.injectUser(response, oidcConfig.userinfo_header_name)
       end
@@ -71,6 +73,7 @@ function handle(oidcConfig)
       elseif response.id_token then
         utils.injectGroups(response.id_token, oidcConfig.groups_claim)
       end
+      utils.injectHeaders(oidcConfig.header_names, oidcConfig.header_claims, { response.user, response.id_token })
       if (not oidcConfig.disable_userinfo_header
           and response.user) then
         utils.injectUser(response.user, oidcConfig.userinfo_header_name)

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -29,6 +29,7 @@ return {
     disable_id_token_header = { type = "string", required = false, default = "no" },
     disable_access_token_header = { type = "string", required = false, default = "no" },
     revoke_tokens_on_logout = { type = "string", required = false, default = "no" },
-    groups_claim = { type = "string", required = false, default = "groups" }
+    groups_claim = { type = "string", required = false, default = "groups" },
+    skip_already_auth_requests = { type = "string", required = false, default = "no" }
   }
 }

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -34,5 +34,7 @@ return {
     bearer_jwt_auth_enable = { type = "string", required = false, default = "no" },
     bearer_jwt_auth_allowed_auds = { type = "array", required = false },
     bearer_jwt_auth_signing_algs = { type = "array", required = true, default = { "RS256" } },
+    header_names = { type = "array", required = true, default = {} },
+    header_claims = { type = "array", required = true, default = {} },
   }
 }

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -30,6 +30,9 @@ return {
     disable_access_token_header = { type = "string", required = false, default = "no" },
     revoke_tokens_on_logout = { type = "string", required = false, default = "no" },
     groups_claim = { type = "string", required = false, default = "groups" },
-    skip_already_auth_requests = { type = "string", required = false, default = "no" }
+    skip_already_auth_requests = { type = "string", required = false, default = "no" },
+    bearer_jwt_auth_enable = { type = "string", required = false, default = "no" },
+    bearer_jwt_auth_allowed_auds = { type = "array", required = false },
+    bearer_jwt_auth_signing_algs = { type = "array", required = true, default = { "RS256" } },
   }
 }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -142,12 +142,15 @@ function M.injectIDToken(idToken, headerName)
   ngx.req.set_header(headerName, ngx.encode_base64(tokenStr))
 end
 
-function M.injectUser(user, headerName)
-  ngx.log(ngx.DEBUG, "Injecting " .. headerName)
+function M.setCredentials(user)
   local tmp_user = user
   tmp_user.id = user.sub
   tmp_user.username = user.preferred_username
   set_consumer(nil, tmp_user)
+end
+
+function M.injectUser(user, headerName)
+  ngx.log(ngx.DEBUG, "Injecting " .. headerName) 
   local userinfo = cjson.encode(user)
   ngx.req.set_header(headerName, ngx.encode_base64(userinfo))
 end

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -70,7 +70,8 @@ function M.get_options(config, ngx)
     disable_userinfo_header = config.disable_userinfo_header == "yes",
     disable_id_token_header = config.disable_id_token_header == "yes",
     disable_access_token_header = config.disable_access_token_header == "yes",
-    groups_claim = config.groups_claim
+    groups_claim = config.groups_claim,
+    skip_already_auth_requests = config.skip_already_auth_requests == "yes"
   }
 end
 

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -72,7 +72,10 @@ function M.get_options(config, ngx)
     disable_id_token_header = config.disable_id_token_header == "yes",
     disable_access_token_header = config.disable_access_token_header == "yes",
     groups_claim = config.groups_claim,
-    skip_already_auth_requests = config.skip_already_auth_requests == "yes"
+    skip_already_auth_requests = config.skip_already_auth_requests == "yes",
+    bearer_jwt_auth_enable = config.bearer_jwt_auth_enable == "yes",
+    bearer_jwt_auth_allowed_auds = config.bearer_jwt_auth_allowed_auds,
+    bearer_jwt_auth_signing_algs = config.bearer_jwt_auth_signing_algs
   }
 end
 
@@ -167,6 +170,29 @@ function M.has_bearer_access_token()
     local divider = header:find(' ')
     if string.lower(header:sub(0, divider-1)) == string.lower("Bearer") then
       return true
+    end
+  end
+  return false
+end
+
+-- verify if tables t1 and t2 have at least one common string item
+-- instead of table, also string can be provided as t1 or t2
+function M.has_common_item(t1, t2)
+  if t1 == nil or t2 == nil then
+    return false
+  end
+  if type(t1) == "string" then
+    t1 = { t1 }
+  end
+  if type(t2) == "string" then
+    t2 = { t2 }
+  end
+  local i1, i2
+  for _, i1 in pairs(t1) do
+    for _, i2 in pairs(t2) do
+      if type(i1) == "string" and type(i2) == "string" and i1 == i2 then
+        return true
+      end
     end
   end
   return false

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -70,7 +70,7 @@ function M.get_options(config, ngx)
     disable_userinfo_header = config.disable_userinfo_header == "yes",
     disable_id_token_header = config.disable_id_token_header == "yes",
     disable_access_token_header = config.disable_access_token_header == "yes",
-    groups_claim = config.groups_claim == "groups"
+    groups_claim = config.groups_claim
   }
 end
 

--- a/test/docker/integration/Dockerfile
+++ b/test/docker/integration/Dockerfile
@@ -1,5 +1,6 @@
 ARG KONG_BASE_TAG
 FROM kong${KONG_BASE_TAG}
+USER root
 
 ENV LUA_PATH /usr/local/share/lua/5.1/?.lua;/usr/local/kong-oidc/?.lua;;
 # For lua-cjson
@@ -12,6 +13,6 @@ RUN luarocks install luaunit
 RUN luarocks install lua-cjson
 
 # Change openidc version when version in rockspec changes
-RUN luarocks install lua-resty-openidc 1.7.2-1
+RUN luarocks install lua-resty-openidc 1.7.4-1
 
 COPY . /usr/local/kong-oidc

--- a/test/docker/unit/Dockerfile
+++ b/test/docker/unit/Dockerfile
@@ -1,6 +1,6 @@
 ARG KONG_BASE_TAG
 FROM kong${KONG_BASE_TAG}
-
+USER root
 ENV LUA_PATH /usr/local/share/lua/5.1/?.lua;/usr/local/kong-oidc/?.lua
 # For lua-cjson
 ENV LUA_CPATH /usr/local/lib/lua/5.1/?.so
@@ -8,7 +8,9 @@ ENV LUA_CPATH /usr/local/lib/lua/5.1/?.so
 # Install unzip for luarocks, gcc for lua-cjson
 RUN echo "ip_resolve=4" >> /etc/yum.conf && yum install -y unzip gcc
 # Change openidc version when version in rockspec changes
-RUN luarocks install lua-resty-openidc 1.7.2-1
+RUN luarocks install lua-resty-openidc 1.7.4-1
+RUN luarocks install luacov
+RUN luarocks install luaunit
 
 WORKDIR /usr/local/kong-oidc
 

--- a/test/unit/mockable_case.lua
+++ b/test/unit/mockable_case.lua
@@ -31,6 +31,23 @@ function MockableCase:setUp()
   self.ngx = _G.ngx
   _G.ngx = self.mocked_ngx
 
+  self.mocked_kong = {
+    client = {
+      authenticate = function(consumer, credential)
+        ngx.ctx.authenticated_consumer = consumer
+        ngx.ctx.authenticated_credential = credential
+      end
+    },
+    service = {
+      request = {
+        clear_header = function(...) end,
+        set_header = function(...) end
+      }
+    }
+  }
+  self.kong = _G.kong
+  _G.kong = self.mocked_kong
+
   self.resty = package.loaded.resty
   package.loaded["resty.http"] = nil
   package.preload["resty.http"] = function()
@@ -50,6 +67,7 @@ end
 function MockableCase:tearDown()
   MockableCase.super:tearDown()
   _G.ngx = self.ngx
+  _G.kong = self.kong
   package.loaded.resty = self.resty
   package.loaded.cjson = self.cjson
 end

--- a/test/unit/mockable_case.lua
+++ b/test/unit/mockable_case.lua
@@ -43,6 +43,12 @@ function MockableCase:setUp()
         clear_header = function(...) end,
         set_header = function(...) end
       }
+    },
+    log = {
+      err = function(...) end
+    },
+    ctx = {
+      shared = {}
     }
   }
   self.kong = _G.kong

--- a/test/unit/run.sh
+++ b/test/unit/run.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -e
 
+rm -f luacov.stats.out
+
 # Run all test_*.lua files in test/unit
 for f in test/unit/test_*.lua; do
   (set -x
     lua -lluacov ${f} -o TAP --failure
   )
 done
+luacov
+cat luacov.report.out

--- a/test/unit/test_already_auth.lua
+++ b/test/unit/test_already_auth.lua
@@ -1,0 +1,44 @@
+local lu = require("luaunit")
+TestHandler = require("test.unit.mockable_case"):extend()
+
+
+function TestHandler:setUp()
+  TestHandler.super:setUp()
+
+  package.loaded["resty.openidc"] = nil
+  self.module_resty = { openidc = {} }
+  package.preload["resty.openidc"] = function()
+    return self.module_resty.openidc
+  end
+
+  self.handler = require("kong.plugins.oidc.handler")()
+end
+
+function TestHandler:tearDown()
+  TestHandler.super:tearDown()
+end
+
+function TestHandler:test_skip_already_auth_has_cred()
+  kong.client.get_credential = function() return { consumer_id = "user" } end
+  local called_authenticate
+  self.module_resty.openidc.authenticate = function(opts)
+    called_authenticate = true
+    return nil, "error"
+  end
+  self.handler:access({ skip_already_auth_requests = "yes" })
+  lu.assertNil(called_authenticate)
+end
+
+function TestHandler:test_skip_already_auth_has_no_cred()
+  kong.client.get_credential = function() return nil end
+  local called_authenticate
+  self.module_resty.openidc.authenticate = function(opts)
+    called_authenticate = true
+    return nil, "error"
+  end
+  self.handler:access({ skip_already_auth_requests = "yes" })
+  lu.assertTrue(called_authenticate)
+end
+
+
+lu.run()

--- a/test/unit/test_bearer_jwt_auth.lua
+++ b/test/unit/test_bearer_jwt_auth.lua
@@ -1,0 +1,68 @@
+local lu = require("luaunit")
+TestHandler = require("test.unit.mockable_case"):extend()
+
+
+function TestHandler:setUp()
+  TestHandler.super:setUp()
+
+  package.loaded["resty.openidc"] = nil
+  self.module_resty = { openidc = {} }
+  package.preload["resty.openidc"] = function()
+    return self.module_resty.openidc
+  end
+
+  self.handler = require("kong.plugins.oidc.handler")()
+end
+
+function TestHandler:tearDown()
+  TestHandler.super:tearDown()
+end
+
+function TestHandler:test_bearer_jwt_auth_success()
+  ngx.req.get_headers = function() return {Authorization = "Bearer xxx"} end
+  ngx.encode_base64 = function(x) return "eyJzdWIiOiJzdWIifQ==" end
+
+  self.module_resty.openidc.get_discovery_doc = function(opts)
+    return { issuer = "https://oidc" }
+  end
+
+  self.module_resty.openidc.bearer_jwt_verify = function(opts)
+    token = { 
+        iss = "https://oidc",
+        sub = "sub111",
+        aud = "aud222",
+        groups = { "users" }
+    }
+    return token, nil, "xxx"
+  end
+
+  self.handler:access({
+    bearer_jwt_auth_enable = "yes",
+    client_id = "aud222",
+    groups_claim = "groups",
+    userinfo_header_name = "x-userinfo"
+  })
+  lu.assertEquals(ngx.ctx.authenticated_credential.id, "sub111")
+  lu.assertEquals(kong.ctx.shared.authenticated_groups, { "users" })
+end
+
+function TestHandler:test_bearer_jwt_auth_fail()
+  ngx.req.get_headers = function() return {Authorization = "Bearer xxx"} end
+  local called_authenticate
+  self.module_resty.openidc.get_discovery_doc = function(opts)
+    return { issuer = "https://oidc" }
+  end
+
+  self.module_resty.openidc.bearer_jwt_verify = function(opts)
+    return nil, "JWT expired"
+  end
+
+  self.module_resty.openidc.authenticate = function(opts)
+    called_authenticate = true
+    return nil, "error"
+  end
+  self.handler:access({bearer_jwt_auth_enable = "yes", client_id = "aud222"})
+  lu.assertTrue(called_authenticate)
+end
+
+lu.run()

--- a/test/unit/test_header_claims.lua
+++ b/test/unit/test_header_claims.lua
@@ -1,0 +1,34 @@
+local lu = require("luaunit")
+TestHandler = require("test.unit.mockable_case"):extend()
+
+function TestHandler:setUp()
+  TestHandler.super:setUp()
+
+  package.loaded["resty.openidc"] = nil
+  self.module_resty = { openidc = {} }
+  package.preload["resty.openidc"] = function()
+    return self.module_resty.openidc
+  end
+
+  self.handler = require("kong.plugins.oidc.handler")()
+end
+
+function TestHandler:tearDown()
+  TestHandler.super:tearDown()
+end
+
+function TestHandler:test_header_add()
+  self.module_resty.openidc.authenticate = function(opts)
+    return { user = {sub = "sub", email = "ghost@localhost"}, id_token = { sub = "sub", aud = "aud123"} }, false
+  end
+  local headers
+  headers = {}
+  kong.service.request.set_header = function(name, value) headers[name] = value end
+
+  self.handler:access({ disable_id_token_header = "yes", disable_userinfo_header = "yes",
+                        header_names = { "X-Email", "X-Aud"}, header_claims = { "email", "aud" } })
+  lu.assertEquals(headers["X-Email"], "ghost@localhost")
+  lu.assertEquals(headers["X-Aud"], "aud123")
+end
+
+lu.run()

--- a/test/unit/test_utils.lua
+++ b/test/unit/test_utils.lua
@@ -77,5 +77,16 @@ function TestUtils:testOptions()
 
 end
 
+function TestUtils:testCommonItem()
+  lu.assertFalse(utils.has_common_item(nil, "aud1"))
+  lu.assertTrue(utils.has_common_item("aud1", "aud1"))
+  lu.assertFalse(utils.has_common_item("aud1", "aud2"))
+  lu.assertFalse(utils.has_common_item({"aud1", "aud2"}, "aud3"))
+  lu.assertTrue(utils.has_common_item({"aud1", "aud2"}, "aud2"))
+  lu.assertFalse(utils.has_common_item("aud1", {"aud2", "aud3"}))
+  lu.assertTrue(utils.has_common_item("aud2", {"aud2", "aud3"}))
+  lu.assertTrue(utils.has_common_item({"aud2","aud3","aud4"}, {"aud4", "aud5"}))
+  lu.assertFalse(utils.has_common_item({"aud2","aud3","aud4"}, {"aud5", "aud6"}))
+end
 
 lu.run()


### PR DESCRIPTION
Hello @cristichiru and all and thanks for your work with the OIDC plugin! This pull request has some patch proposals if you want to check and consider them:

* Fix test environment set-up to work with current kong
* Fix use of groups_claim config parameter
* Add option skip_already_auth_requests for partial plugin chaining support
* Use kong.client.authenticate and set_consumer to inject user
* Inject groups and set credentials regardless of disable_userinfo_header value
* Add feature to auth based on JWT Bearer (ID) token in Authorization header
* Honor disable_userinfo_header on bearer token auth
* Add feature to inject custom headers based on claims
* Upgrade lua-resty-openidc to 1.7.4-1

For now for visibility these are all bundled in this single PR but as separate commits. If needed I could open them separately (but then some sequentially due to dependencies), but wanted to first hear your thoughts.

These are mostly backward compatible but there are some behavior changes due to the fixes/changes. Some notes could be compiled to docker-kong-oidc changelog if applying these. There is some info in individual commit messages.

Please have look and let know  :)