### PR TITLE
What is the "session freeze"?

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ It maintains sessions for authenticated users by leveraging `lua-resty-openidc` 
 a configurable choice between storing the session state in a client-side browser cookie or use
 in of the server-side storage mechanisms `shared-memory|memcache|redis`.
 
+
+???
 > **Note:** at the moment, there is an issue using memcached/redis, probably due to session locking: the sessions freeze. Help to debug this is appreciated. I am currently using shared memory to store sessions.
+???
+
 
 It supports server-wide caching of resolved Discovery documents and validated Access Tokens.
 


### PR DESCRIPTION
This made me worry a bit
> Note: at the moment, there is an issue using memcached/redis, probably due to session locking: the sessions freeze. Help to debug this is appreciated. I am currently using shared memory to store sessions.

Anyone here knows more about this issue? 
Is it still there? What happens when it happens? 
How can I test / reproduce this?

I wasn't able to find anything about this here or in any of the relatet repos.

@cristichiru commited the note (can't tag him :/)