### PR TITLE
fix scope validation

### DIFF
--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -131,11 +131,13 @@ function introspect(oidcConfig)
     -- authorization - validate scope
     if oidcConfig.validate_scope == "yes" then
       local validScope = false
-      for scope in res.scope:gmatch("([^ ]+)") do
-        if scope == oidcConfig.scope then
-          validScope = true
-          break
-        end
+      if res.scope then
+        for scope in res.scope:gmatch("([^ ]+)") do
+          if scope == oidcConfig.scope then
+            validScope = true
+            break
+          end
+        end  
       end
       if not validScope then
         utils.exit(ngx.HTTP_FORBIDDEN,"Invalid scope",ngx.HTTP_FORBIDDEN)

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -128,7 +128,6 @@ function introspect(oidcConfig)
       end
       return nil
     end
-    -- authorization - validate scope
     if oidcConfig.validate_scope == "yes" then
       local validScope = false
       if res.scope then
@@ -137,7 +136,7 @@ function introspect(oidcConfig)
             validScope = true
             break
           end
-        end  
+        end
       end
       if not validScope then
         utils.exit(ngx.HTTP_FORBIDDEN,"Invalid scope",ngx.HTTP_FORBIDDEN)


### PR DESCRIPTION
when scope validation is active but token introspection response doesn't contains a scope claim the code fails because it's always expecting scope claim to exist. This commit fixes that scenario so independently of scope claim exist in introspection response it always behaves correctly.