### PR TITLE
Align error response bodies with Kong official plugins

### DIFF
--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -101,13 +101,13 @@ function make_oidc(oidcConfig)
 
   if err then
     if err == 'unauthorized request' then
-      utils.exit(ngx.HTTP_UNAUTHORIZED, err)
+      return kong.response.error(ngx.HTTP_UNAUTHORIZED)
     else
       if oidcConfig.recovery_page_path then
     	  ngx.log(ngx.DEBUG, "Redirecting to recovery page: " .. oidcConfig.recovery_page_path)
         ngx.redirect(oidcConfig.recovery_page_path)
       end
-      utils.exit(ngx.HTTP_INTERNAL_SERVER_ERROR, err)
+      return kong.response.error(ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
   end
   return res
@@ -124,7 +124,7 @@ function introspect(oidcConfig)
     if err then
       if oidcConfig.bearer_only == "yes" then
         ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. oidcConfig.realm .. '",error="' .. err .. '"'
-        utils.exit(ngx.HTTP_UNAUTHORIZED, err)
+        return kong.response.error(ngx.HTTP_UNAUTHORIZED)
       end
       return nil
     end
@@ -139,7 +139,8 @@ function introspect(oidcConfig)
         end
       end
       if not validScope then
-        utils.exit(ngx.HTTP_FORBIDDEN, 'Scope validation failed')
+        kong.log.err("Scope validation failed")
+        return kong.response.error(ngx.HTTP_FORBIDDEN)
       end
     end
     ngx.log(ngx.DEBUG, "OidcHandler introspect succeeded, requested path: " .. ngx.var.request_uri)

--- a/kong/plugins/oidc/session.lua
+++ b/kong/plugins/oidc/session.lua
@@ -6,7 +6,8 @@ function M.configure(config)
   if config.session_secret then
     local decoded_session_secret = ngx.decode_base64(config.session_secret)
     if not decoded_session_secret then
-      utils.exit(ngx.HTTP_INTERNAL_SERVER_ERROR, 'Invalid plugin configuration, session secret could not be decoded')
+      kong.log.err("Invalid plugin configuration, session secret could not be decoded")
+      return kong.response.error(ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
     ngx.var.session_secret = decoded_session_secret
   end

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -84,13 +84,6 @@ function M.get_options(config, ngx)
   }
 end
 
-function M.exit(statusCode, message)
-  ngx.status = statusCode
-  kong.log.err(message)
-  ngx.exit(statusCode)
-end
-
-
 -- Function set_consumer is derived from the following kong auth plugins:
 -- https://github.com/Kong/kong/blob/2.2.0/kong/plugins/ldap-auth/access.lua
 -- https://github.com/Kong/kong/blob/2.2.0/kong/plugins/oauth2/access.lua
@@ -99,39 +92,36 @@ end
 local function set_consumer(consumer, credential)
   kong.client.authenticate(consumer, credential)
 
-  local set_header = kong.service.request.set_header
-  local clear_header = kong.service.request.clear_header
-
   if consumer and consumer.id then
-    set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+    kong.service.request.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
   else
-    clear_header(constants.HEADERS.CONSUMER_ID)
+    kong.service.request.clear_header(constants.HEADERS.CONSUMER_ID)
   end
 
   if consumer and consumer.custom_id then
-    set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+    kong.service.request.set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
   else
-    clear_header(constants.HEADERS.CONSUMER_CUSTOM_ID)
+    kong.service.request.clear_header(constants.HEADERS.CONSUMER_CUSTOM_ID)
   end
 
   if consumer and consumer.username then
-    set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+    kong.service.request.set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
   else
-    clear_header(constants.HEADERS.CONSUMER_USERNAME)
+    kong.service.request.clear_header(constants.HEADERS.CONSUMER_USERNAME)
   end
 
   if credential and credential.sub then
-    set_header(constants.HEADERS.CREDENTIAL_IDENTIFIER, credential.sub)
+    kong.service.request.set_header(constants.HEADERS.CREDENTIAL_IDENTIFIER, credential.sub)
   else
-    clear_header(constants.HEADERS.CREDENTIAL_IDENTIFIER)
+    kong.service.request.clear_header(constants.HEADERS.CREDENTIAL_IDENTIFIER)
   end
 
-  clear_header(constants.HEADERS.CREDENTIAL_USERNAME)
+  kong.service.request.clear_header(constants.HEADERS.CREDENTIAL_USERNAME)
 
   if credential then
-    clear_header(constants.HEADERS.ANONYMOUS)
+    kong.service.request.clear_header(constants.HEADERS.ANONYMOUS)
   else
-    set_header(constants.HEADERS.ANONYMOUS, true)
+    kong.service.request.set_header(constants.HEADERS.ANONYMOUS, true)
   end
 end
 
@@ -141,13 +131,13 @@ function M.injectAccessToken(accessToken, headerName, bearerToken)
   if (bearerToken) then
     token = formatAsBearerToken(token)
   end
-  ngx.req.set_header(headerName, token)
+  kong.service.request.set_header(headerName, token)
 end
 
 function M.injectIDToken(idToken, headerName)
   ngx.log(ngx.DEBUG, "Injecting " .. headerName)
   local tokenStr = cjson.encode(idToken)
-  ngx.req.set_header(headerName, ngx.encode_base64(tokenStr))
+  kong.service.request.set_header(headerName, ngx.encode_base64(tokenStr))
 end
 
 function M.setCredentials(user)
@@ -160,7 +150,7 @@ end
 function M.injectUser(user, headerName)
   ngx.log(ngx.DEBUG, "Injecting " .. headerName)
   local userinfo = cjson.encode(user)
-  ngx.req.set_header(headerName, ngx.encode_base64(userinfo))
+  kong.service.request.set_header(headerName, ngx.encode_base64(userinfo))
 end
 
 function M.injectGroups(user, claim)

--- a/test/unit/mockable_case.lua
+++ b/test/unit/mockable_case.lua
@@ -46,6 +46,11 @@ function MockableCase:setUp()
         set_header = function(...) end
       }
     },
+    response = {
+      error = function(status)
+        ngx.status = status
+      end
+    },
     log = {
       err = function(...) end
     },

--- a/test/unit/test_header_claims.lua
+++ b/test/unit/test_header_claims.lua
@@ -21,8 +21,7 @@ function TestHandler:test_header_add()
   self.module_resty.openidc.authenticate = function(opts)
     return { user = {sub = "sub", email = "ghost@localhost"}, id_token = { sub = "sub", aud = "aud123"} }, false
   end
-  local headers
-  headers = {}
+  local headers = {}
   kong.service.request.set_header = function(name, value) headers[name] = value end
 
   self.handler:access({ disable_id_token_header = "yes", disable_userinfo_header = "yes",

--- a/test/unit/test_introspect.lua
+++ b/test/unit/test_introspect.lua
@@ -28,10 +28,8 @@ function TestIntrospect:test_access_token_exists()
   end
 
   local headers = {}
-  ngx.req.set_header = function(h, v)
-    headers[h] = v
-  end
-
+  kong.service.request.set_header = function(name, value) headers[name] = value end
+  
   self.handler:access({introspection_endpoint = "x", userinfo_header_name = "X-Userinfo"})
   lu.assertTrue(self:log_contains("introspect succeeded"))
   lu.assertEquals(headers['X-Userinfo'], "eyJzdWIiOiJzdWIifQ==")
@@ -49,9 +47,7 @@ function TestIntrospect:test_no_authorization_header()
   ngx.req.get_headers = function() return {} end
 
   local headers = {}
-  ngx.req.set_header = function(h, v)
-    headers[h] = v
-  end
+  kong.service.request.set_header = function(name, value) headers[name] = value end
 
   self.handler:access({introspection_endpoint = "x", userinfo_header_name = "X-Userinfo"})
   lu.assertFalse(self:log_contains(self.mocked_ngx.ERR))


### PR DESCRIPTION
Historically, default NGINX error messages have text/html bodies (NGINX started as proxy for Web Applications which are HTML based).

This PR aligns error handling with all other Kong official plugins by sending response bodies as JSON rather than HTML.