### PR TITLE
Added option to use Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ If you're using `luarocks` execute the following:
 | `config.bearer_jwt_auth_signing_algs`       | [ 'RS256' ]                                | false    | List of allowed signing algorithms for Authorization header JWT token validation. Must match to OIDC provider and `resty-openidc` supported algorithms                                  |
 | `config.header_names`                       |                                            | false    | List of custom upstream HTTP headers to be added based on claims. Must have same number of elements as `config.header_claims`. Example: `[ 'x-oidc-email', 'x-oidc-email-verified' ]`   |
 | `config.header_claims`                      |                                            | false    | List of claims to be used as source for custom upstream headers. Claims are sourced from Userinfo, ID Token, Bearer JWT, Introspection, depending on auth method.  Use only claims containing simple string values. Example: `[ 'email', 'email_verified'` |
+| `config.http_proxy` || false | http proxy url |
+| `config.https_proxy` || false | https proxy url (only supports url format __http__://proxy and not __https__://proxy) |
 
 ### Enabling kong-oidc
 

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -293,6 +293,18 @@ return {
               },
               default = {}
             }
+          },
+          {
+            http_proxy = {
+              type = "string",
+              required = false
+            }
+          },
+          {
+            https_proxy = {
+              type = "string",
+              required = false
+            }
           }
         }
       }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -83,7 +83,11 @@ function M.get_options(config, ngx)
     bearer_jwt_auth_allowed_auds = config.bearer_jwt_auth_allowed_auds,
     bearer_jwt_auth_signing_algs = config.bearer_jwt_auth_signing_algs,
     header_names = config.header_names or {},
-    header_claims = config.header_claims or {}
+    header_claims = config.header_claims or {},
+    proxy_opts = {
+      http_proxy  = config.http_proxy,
+      https_proxy = config.https_proxy
+    }
   }
 end
 


### PR DESCRIPTION
This is the initial Pull Request, created in nokia/kong-oidc by troll ([PR](https://github.com/nokia/kong-oidc/pull/85)).

This PR adds ability to use http/https Proxy. 

The use-case could be if you are behind corporate proxy, thus `discovery` not being accessible. If `http_proxy` and `https_proxy` variables are being used, then you should also see next lines in logs:
```bash
[debug] 2368#0: *6148 [lua] openidc.lua:430: openidc_configure_proxy(): openidc_configure_proxy : use http proxy
```  

instead of
```bash
[debug] 2368#0: *6148 [lua] openidc.lua:430: openidc_configure_proxy(): openidc_configure_proxy : don't use http proxy
```

👍🏻 