### PR TITLE
updated rock spec to match requirements for kong plugins

### DIFF
--- a/kong-plugin-oidc-1.4.0-1.rockspec
+++ b/kong-plugin-oidc-1.4.0-1.rockspec
@@ -1,4 +1,4 @@
-package = "kong-oidc"
+package = "kong-plugin-oidc"
 version = "1.4.0-1"
 source = {
     url = "git://github.com/revomatico/kong-oidc",
@@ -18,7 +18,7 @@ description = {
 
         It can be used as a reverse proxy terminating OAuth/OpenID Connect in front of an origin server so that the origin server/services can be protected with the relevant standards without implementing those on the server itself.
     ]],
-    homepage = "https://github.com/nokia/kong-oidc",
+    homepage = "git://github.com/revomatico/kong-oidc",
     license = "Apache 2.0"
 }
 dependencies = {


### PR DESCRIPTION
Kong has specific requirements in naming of kong plugins. Several issues have been opened in the past: #28 #20 
