### PR TITLE
make secrets fields referenceable to be handle by vault secret management

### DIFF
--- a/kong-plugin-oidc-1.4.0-1.rockspec
+++ b/kong-plugin-oidc-1.4.0-1.rockspec
@@ -1,9 +1,8 @@
 package = "kong-plugin-oidc"
 version = "1.4.0-1"
 source = {
-    url = "git://github.com/revomatico/kong-oidc",
-    tag = "master",
-    dir = "kong-oidc"
+    url = "git://github.com/revomatico/kong-oidc.git",
+    tag = "master"
 }
 description = {
     summary = "A Kong plugin for implementing the OpenID Connect Relying Party (RP) functionality",
@@ -27,10 +26,10 @@ dependencies = {
 build = {
     type = "builtin",
     modules = {
-    ["kong.plugins.oidc.filter"] = "kong/plugins/oidc/filter.lua",
-    ["kong.plugins.oidc.handler"] = "kong/plugins/oidc/handler.lua",
-    ["kong.plugins.oidc.schema"] = "kong/plugins/oidc/schema.lua",
-    ["kong.plugins.oidc.session"] = "kong/plugins/oidc/session.lua",
-    ["kong.plugins.oidc.utils"] = "kong/plugins/oidc/utils.lua"
+        ["kong.plugins.oidc.filter"]  = "kong/plugins/oidc/filter.lua",
+        ["kong.plugins.oidc.handler"] = "kong/plugins/oidc/handler.lua",
+        ["kong.plugins.oidc.schema"]  = "kong/plugins/oidc/schema.lua",
+        ["kong.plugins.oidc.session"] = "kong/plugins/oidc/session.lua",
+        ["kong.plugins.oidc.utils"]   = "kong/plugins/oidc/utils.lua"
     }
 }

--- a/kong-plugin-oidc-1.4.0-1.rockspec
+++ b/kong-plugin-oidc-1.4.0-1.rockspec
@@ -21,7 +21,7 @@ description = {
     license = "Apache 2.0"
 }
 dependencies = {
-    "lua-resty-openidc ~> 1.7.6-3"
+    "lua-resty-openidc ~> 1.8.0-1"
 }
 build = {
     type = "builtin",

--- a/kong-plugin-oidc-1.4.0-1.rockspec
+++ b/kong-plugin-oidc-1.4.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "kong-plugin-oidc"
 version = "1.4.0-1"
 source = {
-    url = "git://github.com/revomatico/kong-oidc.git",
+    url = "git://github.com/quicksign/kong-oidc.git",
     tag = "master"
 }
 description = {
@@ -17,7 +17,7 @@ description = {
 
         It can be used as a reverse proxy terminating OAuth/OpenID Connect in front of an origin server so that the origin server/services can be protected with the relevant standards without implementing those on the server itself.
     ]],
-    homepage = "git://github.com/revomatico/kong-oidc",
+    homepage = "git://github.com/quicksign/kong-oidc",
     license = "Apache 2.0"
 }
 dependencies = {

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -95,6 +95,7 @@ function make_oidc(oidcConfig)
   local res, err = require("resty.openidc").authenticate(oidcConfig, ngx.var.request_uri, unauth_action)
 
   if err then
+    kong.log.err("Authentication failed: " .. err)
     if err == 'unauthorized request' then
       return kong.response.error(ngx.HTTP_UNAUTHORIZED)
     else
@@ -117,6 +118,7 @@ function introspect(oidcConfig)
       res, err = require("resty.openidc").introspect(oidcConfig)
     end
     if err then
+      kong.log.err("Introspect failed: " .. err)
       if oidcConfig.bearer_only == "yes" then
         ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. oidcConfig.realm .. '",error="' .. err .. '"'
         return kong.response.error(ngx.HTTP_UNAUTHORIZED)

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -1,5 +1,5 @@
 local OidcHandler = {
-    VERSION = "1.3.0",
+    VERSION = "1.4.0",
     PRIORITY = 1000,
 }
 local utils = require("kong.plugins.oidc.utils")

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -18,13 +18,15 @@ return {
           {
             client_id = {
               type = "string",
-              required = true
+              required = true,
+              referenceable = true
             }
           },
           {
             client_secret = {
               type = "string",
-              required = true
+              required = true,
+              referenceable = true
             }
           },
           {
@@ -123,7 +125,8 @@ return {
           {
             session_secret = {
               type = "string",
-              required = false
+              required = false,
+              referenceable = true
             }
           },
           {


### PR DESCRIPTION
This PR add support for Kong Vault secrets as environment variables.
https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/

Example usage on Kong deployed with Helm chart.

Helm chart values:
```yaml
customEnv:
  oidc_quicksign_sso_client_id: "client_id"
  oidc_quicksign_sso_client_secret: "client_secret"
```

Kong plugin
```yaml
apiVersion: configuration.konghq.com/v1
kind: KongClusterPlugin
metadata:
  name: oidc-sso
plugin: oidc
config:
  client_id: "{vault://env/oidc_quicksign_sso_client_id}"
  client_secret: "{vault://env/oidc_quicksign_sso_client_secret}"
  realm: master
  discovery: https://mydomain/auth/realms/master/.well-known/openid-configuration
```
